### PR TITLE
Update metadata.rb for Chef 11 compatibility.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,8 @@ maintainer_email 'jsirex@gmail.com'
 license          'Apache 2'
 description      'Installs/Configures simple-logstash. No less. No more.'
 long_description 'Installs/Configures simple-logstash. No less. No more.'
-issues_url       'https://github.com/jsirex/simple-logstash-cookbook/issues'
-source_url       'https://github.com/jsirex/simple-logstash-cookbook'
+issues_url       'https://github.com/jsirex/simple-logstash-cookbook/issues' if respond_to?(:issues_url)
+source_url       'https://github.com/jsirex/simple-logstash-cookbook' if respond_to?(:source_url)
 version          '0.2.4'
 
 supports 'debian'


### PR DESCRIPTION
The `issues_url` and `source_url` components in `metadata.rb` only work in Chef 12.x. This PR adds compatibility for Chef 11.x. 

See more details here: https://github.com/parallels-cookbooks/cookbook-logstash-forwarder/issues/3
