### PR TITLE
use short flags to make compatible with latest logstash version

### DIFF
--- a/libraries/resource_logstash_service.rb
+++ b/libraries/resource_logstash_service.rb
@@ -84,9 +84,9 @@ class Chef
 
       def logstash_args
         args = []
-        args << "--config #{logstash_config_path}"
-        args << "--pluginpath #{logstash_plugin_path}" if logstash_plugin_path
-        args << "--filterworkers #{logstash_filter_workers}"
+        args << "-f #{logstash_config_path}"
+        args << "-p #{logstash_plugin_path}" if logstash_plugin_path
+        args << "-w #{logstash_filter_workers}"
         args << '--quiet' if logstash_quiet
         args << '--verbose' if logstash_verbose
         args << '--debug' if logstash_debug


### PR DESCRIPTION
@jsirex 

This pull request changes the long command line flag name to the short command line flag so all Logstash version can work with this cookbook. Please review and test.