### PR TITLE
Making this cookbook compatible with older versions of Ubuntu

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -40,6 +40,13 @@ platforms:
     run_list:
       - recipe[apt]
 
+  - name: ubuntu-14
+    driver:
+      image: dokken/ubuntu-14.04
+      pid_one_command: /bin/systemd
+    run_list:
+      - recipe[apt]
+
   - name: centos-7
     driver:
       image: dokken/centos-7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,8 @@ Metrics/AbcSize:
   Max: 60
 
 Metrics/BlockLength:
-  Max: 40
+  # need a big block size for rspec
+  Max: 100
 
 Style/Documentation:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ You can visit fixture cookbook [simple-logstash-test](test/fixtures/cookbooks/si
 ## Cookbooks:
 
 * ark
+* runit
 
 # Attributes
 
@@ -91,6 +92,7 @@ You can visit fixture cookbook [simple-logstash-test](test/fixtures/cookbooks/si
 * `node['logstash']['user']` -  Defaults to `logstash`.
 * `node['logstash']['group']` -  Defaults to `logstash`.
 * `node['logstash']['prefix_root']` -  Defaults to `/opt`.
+* `node['logstash']['init_style']` -  Defaults to `nil # 'systemd' (default) or 'runit`.
 
 # Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,3 +7,7 @@ default['logstash']['version'] = '1.5.6'
 default['logstash']['user'] = 'logstash'
 default['logstash']['group'] = 'logstash'
 default['logstash']['prefix_root'] = '/opt'
+
+# by default, logstash services are managed by systemd
+# you can have them managed by runit instead
+default['logstash']['init_style'] = nil # 'systemd' (default) or 'runit'

--- a/libraries/logstash_service_base.rb
+++ b/libraries/logstash_service_base.rb
@@ -8,6 +8,7 @@ module SimpleLogstashCookbook
     property :group, String, default: 'logstash', desired_state: false
     property :daemon_path, String, default: '/opt/logstash/bin/logstash', desired_state: false
     property :env, Hash, default: {}, desired_state: false
+    property :timeout_sec, [Integer, NilClass], default: nil, desired_state: false
     property :logstash_config_path, String, default: lazy { default_config_path }, desired_state: false
     property :logstash_plugin_path, String, desired_state: false
     property :logstash_filter_workers, Integer, default: 1, desired_state: false

--- a/libraries/logstash_service_base.rb
+++ b/libraries/logstash_service_base.rb
@@ -20,23 +20,14 @@ module SimpleLogstashCookbook
     default_action :start
     allowed_actions :start, :stop, :restart
 
-    def provider(arg = nil)
-      result = super
-
-      if arg.nil? && !node['logstash']['init_style'].nil?
-        resource_class = case node['logstash']['init_style']
-                         when 'systemd'
-                           SimpleLogstashCookbook::LogstashServiceSystemd
-                         when 'runit'
-                           SimpleLogstashCookbook::LogstashServiceRunit
-                         else
-                           Chef::Log.warn("Ignoring invalid init style #{node['logstash']['default_init_style']} for Logstash")
-                         end
-
-        result = resource_class.action_class if resource_class
+    def self.provides(*args, **kwargs)
+      super(*args, **kwargs) do |node|
+        if node['logstash']['init_style'].nil? || node['logstash']['init_style'] == self::LOGSTASH_INIT_STYLE
+          block_given? ? yield(node) : true
+        else
+          false
+        end
       end
-
-      result
     end
 
     def default_config_path

--- a/libraries/logstash_service_runit.rb
+++ b/libraries/logstash_service_runit.rb
@@ -24,6 +24,7 @@ module SimpleLogstashCookbook
           default_logger true
           options(new_resource: new_resource)
           env new_resource.env
+          sv_timeout new_resource.timeout_sec unless new_resource.timeout_sec.nil?
 
           action :nothing
         end

--- a/libraries/logstash_service_runit.rb
+++ b/libraries/logstash_service_runit.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
+# this ensures that the systemd resource file is loaded before this one, thus
+# making it the default resource for platforms provided for by both resources
+require_relative 'logstash_service_systemd'
+
 module SimpleLogstashCookbook
   class LogstashServiceRunit < LogstashServiceBase
     resource_name :logstash_service_runit
 
-    provides :logstash_service, platform: 'ubuntu' do |node|
-      node['platform_version'].to_f >= 12.04
-    end
+    LOGSTASH_INIT_STYLE = 'runit'
 
+    provides :logstash_service, os: 'linux'
     provides :logstash_service_runit, os: 'linux'
 
     action_class do

--- a/libraries/logstash_service_runit.rb
+++ b/libraries/logstash_service_runit.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module SimpleLogstashCookbook
+  class LogstashServiceRunit < LogstashServiceBase
+    resource_name :logstash_service_runit
+
+    provides :logstash_service, platform: 'ubuntu' do |node|
+      node['platform_version'].to_f >= 12.04
+    end
+
+    provides :logstash_service_runit, os: 'linux'
+
+    action_class do
+      def whyrun_supported?
+        true
+      end
+
+      def service_resource
+        find_resource(:runit_service, new_resource.instance_name) do
+          cookbook 'simple-logstash'
+          default_logger true
+          options(new_resource: new_resource)
+          env new_resource.env
+
+          action :nothing
+        end
+      end
+    end
+
+    action :start do
+      service_resource.action += [:create, :enable, :start]
+    end
+
+    action :stop do
+      service_resource.action += [:stop, :disable]
+    end
+
+    action :restart do
+      service_resource.action += [:create, :enable, :restart]
+    end
+  end
+end

--- a/libraries/logstash_service_systemd.rb
+++ b/libraries/logstash_service_systemd.rb
@@ -42,7 +42,9 @@ module SimpleLogstashCookbook
             'Unit' => {
               'Description' => "Logstash #{new_resource.instance_name} service",
               'After' => 'network.target',
-              'Documentation' => 'https://www.elastic.co/products/logstash'
+              'Documentation' => 'https://www.elastic.co/products/logstash',
+              # see https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+              'JobTimeoutSec' => new_resource.timeout_sec.nil? ? 'infinity' : new_resource.timeout_sec
             },
             'Service' => {
               'User' => new_resource.user,

--- a/libraries/logstash_service_systemd.rb
+++ b/libraries/logstash_service_systemd.rb
@@ -4,6 +4,8 @@ module SimpleLogstashCookbook
   class LogstashServiceSystemd < LogstashServiceBase
     resource_name :logstash_service_systemd
 
+    LOGSTASH_INIT_STYLE = 'systemd'
+
     provides :logstash_service, platform: 'debian' do |node| # ~FC005
       node['platform_version'].to_f >= 8.0
     end

--- a/libraries/logstash_service_systemd.rb
+++ b/libraries/logstash_service_systemd.rb
@@ -45,7 +45,7 @@ module SimpleLogstashCookbook
             'Service' => {
               'User' => new_resource.user,
               'Group' => new_resource.group,
-              'ExecStart' => "#{new_resource.daemon_path} #{new_resource.logstash_args}",
+              'ExecStart' => new_resource.full_logstash_command,
               'EnvironmentFile' => "/etc/default/#{new_resource.instance_name}",
               'Restart' => 'always',
               'RestartSec' => '1 min',

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,7 @@ supports 'ubuntu', '>= 16.0'
 supports 'centos', '>= 7.0'
 
 depends 'ark'
+depends 'runit'
 
 chef_version '>= 12.6'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+include_recipe 'runit' if node['logstash']['init_style'] == 'runit' || !SimpleLogstashCookbook::LogstashServiceSystemd.provides?(node, 'logstash_service')
+
 user 'logstash user' do
   username node['logstash']['user']
   comment 'Logstash User'

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -3,8 +3,26 @@
 require 'spec_helper'
 
 describe 'simple-logstash-test::default' do
-  cached(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'debian', version: '9.1').converge(described_recipe)
+  let(:platform) { 'debian' }
+  let(:platform_version) { '9.1' }
+  let(:node_attributes) { {} }
+
+  let(:runner_options) do
+    {
+      platform: platform,
+      version: platform_version,
+      step_into: %w[logstash_service]
+    }
+  end
+
+  let(:runner) do
+    ChefSpec::SoloRunner.new(**runner_options) do |node|
+      node_attributes.each { |k, v| node.override['logstash'][k] = v }
+    end
+  end
+
+  let(:chef_run) do
+    runner.converge(described_recipe)
   end
 
   it 'enables logstash service' do
@@ -13,6 +31,11 @@ describe 'simple-logstash-test::default' do
 
   it 'enables logstash-two service' do
     expect(chef_run).to start_logstash_service('logstash-two')
+  end
+
+  it 'uses the systemd provider by default' do
+    expect(chef_run).to start_systemd_unit('logstash.service')
+    expect(chef_run).to start_systemd_unit('logstash-two.service')
   end
 
   %w[test1 test2 test3].each do |tst|
@@ -33,5 +56,34 @@ describe 'simple-logstash-test::default' do
 
   it 'creates samples directory for tests' do
     expect(chef_run).to create_remote_directory('/tmp/samples')
+  end
+
+  context 'on ubuntu 14.04' do
+    let(:platform) { 'ubuntu' }
+    let(:platform_version) { '14.04' }
+
+    it 'enables logstash service' do
+      expect(chef_run).to start_logstash_service('logstash')
+    end
+
+    it 'uses the runit provider, since systemd does not exist on ubuntu 14.04' do
+      expect(chef_run).to start_runit_service('logstash')
+    end
+
+    it 'includes the runit default recipe' do
+      expect(chef_run).to include_recipe('runit')
+    end
+  end
+
+  context 'when explicitly asked to use runit' do
+    let(:node_attributes) { { 'init_style' => 'runit' } }
+
+    it 'does so' do
+      expect(chef_run).to start_runit_service('logstash')
+    end
+
+    it 'includes the runit default recipe' do
+      expect(chef_run).to include_recipe('runit')
+    end
   end
 end

--- a/templates/default/sv-logstash-run.erb
+++ b/templates/default/sv-logstash-run.erb
@@ -1,0 +1,11 @@
+#!/bin/sh
+<% new_resource = @options[:new_resource] -%>
+
+exec 2>&1
+
+ulimit -n <%= new_resource.logstash_max_file_descriptors %>
+
+exec <%= node['runit']['chpst_bin'] %> \
+    -u <%= new_resource.user %>:<%= new_resource.group %> \
+    -e <%= "/etc/sv/#{new_resource.instance_name}/env" %> \
+    -- <%= new_resource.full_logstash_command %>


### PR DESCRIPTION
By using `runit` to manage the Logstash services when systemd is not around.

As a bonus, made it possible to choose `runit` even when systemd is available.

Added tests.