### PR TITLE
Add ability to set systemd unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Consider:
 - **pipeline_workers** - number of working threads. See logstash documentation. Defaults to `1`
 - **max_open_files** - sets maximum files allowed to open by process. Defaults to `16384`
 - **custom_args** - optional string with additional custom arguments passed to logstash. Defaults to `''`
+- **systemd_unit_hash** - optional string or hash with custom systemd unit. Defaults to [this](https://github.com/jsirex/simple-logstash-cookbook/blob/master/libraries/logstash_service_systemd.rb#L22)
 
 Attributes to customize logstash flags:
 

--- a/spec/logstash_service_spec.rb
+++ b/spec/logstash_service_spec.rb
@@ -23,6 +23,12 @@ describe 'simple-logstash-spec::logstash_service' do
       expect(lservice.action).to include(:start)
     end
 
+    it 'uses systemd provided unit' do
+      lservice = chef_run.logstash_service_systemd('systemd-unit')
+      expect(lservice.resource_name).to eq(:logstash_service_systemd)
+      expect(lservice.action).to include(:start)
+    end
+
     it 'uses runit' do
       lservice = chef_run.logstash_service_runit('runit-explicit')
       expect(lservice.resource_name).to eq(:logstash_service_runit)

--- a/test/fixtures/cookbooks/simple-logstash-spec/recipes/logstash_service.rb
+++ b/test/fixtures/cookbooks/simple-logstash-spec/recipes/logstash_service.rb
@@ -15,3 +15,29 @@ end
 logstash_service 'runit-provider' do
   provider :logstash_service_runit
 end
+
+content = {
+  'Unit' => {
+    'Description' => "Logstash service",
+    'After' => 'network.target',
+    'Documentation' => 'https://www.elastic.co/products/logstash'
+  },
+  'Service' => {
+    'User' => 'Logstash',
+    'Group' => 'Logstash',
+    'ExecStart' => '/opt/logstash/bin/logstash --path.config /etc/logstash/conf.d --path.data /var/lib/logstash/data --path.logs /var/log/logstash --pipeline.workers 1 --config.reload.automatic --log.level error',
+    'EnvironmentFile' => '/etc/default/logstash',
+    'Restart' => 'always',
+    'RestartSec' => '1 min',
+    'LimitNICE' => 19,
+    'LimitNOFILE' => '16384'
+  },
+  'Install' => {
+    'WantedBy' => 'multi-user.target'
+  },
+}
+
+logstash_service_systemd 'systemd-unit' do
+  provider :logstash_service_systemd
+  systemd_unit_hash content
+end


### PR DESCRIPTION
## What does this do?
Adds the ability to provide a custom string/hash for the systemd unit content

## Why do we need it?
To provide more granular configuration for the logstash service such as setting `CPUAffinity`

- [x] added a test for the new functionality
- [x] tests pass
