### PR TITLE
Fix systemd unit addition and add better tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -53,3 +53,7 @@ suites:
     attributes:
       logstash:
         # download_url: http://nexus.e3s.epam.com/repository/e3s-install/logstash/6.2.3/logstash-6.2.3.tar.gz
+
+  - name: systemd-unit
+    run_list:
+      - recipe[simple-logstash-test::systemd-unit]

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ Consider:
 - **pipeline\_workers** - number of working threads. See logstash documentation. Defaults to `1`
 - **max\_open\_files** - sets maximum files allowed to open by process. Defaults to `16384`
 - **custom\_args** - optional string with additional custom arguments passed to logstash. Defaults to `''`
-- **systemd_unit_hash** - optional string or hash with custom systemd unit. Defaults to [this](https://github.com/jsirex/simple-logstash-cookbook/blob/master/libraries/logstash_service_systemd.rb#L22)
 
 Attributes to customize logstash flags:
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Consider:
 - **pipeline\_workers** - number of working threads. See logstash documentation. Defaults to `1`
 - **max\_open\_files** - sets maximum files allowed to open by process. Defaults to `16384`
 - **custom\_args** - optional string with additional custom arguments passed to logstash. Defaults to `''`
+- **systemd_unit_hash** - optional string or hash with custom systemd unit. Defaults to [this](https://github.com/jsirex/simple-logstash-cookbook/blob/master/libraries/logstash_service_systemd.rb#L22)
 
 Attributes to customize logstash flags:
 

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -93,6 +93,7 @@ Consider:
 - **pipeline\_workers** - number of working threads. See logstash documentation. Defaults to `1`
 - **max\_open\_files** - sets maximum files allowed to open by process. Defaults to `16384`
 - **custom\_args** - optional string with additional custom arguments passed to logstash. Defaults to `''`
+- **systemd\_unit\_hash** - optional string or hash with custom systemd unit. Defaults to [this](https://github.com/jsirex/simple-logstash-cookbook/blob/master/libraries/logstash_service_systemd.rb#L22)
 
 Attributes to customize logstash flags:
 

--- a/libraries/logstash_service_base.rb
+++ b/libraries/logstash_service_base.rb
@@ -45,7 +45,7 @@ module SimpleLogstashCookbook
       args << "#{config_path_flag} #{config_path}" unless config_path_flag.empty? || config_path.empty?
       args << "#{data_path_flag} #{data_path}" unless data_path_flag.empty? || data_path.empty?
       args << "#{logs_path_flag} #{logs_path}" unless logs_path_flag.empty? || logs_path.empty?
-      args << "#{pipeline_workers_flag} #{pipeline_workers}" unless pipeline_workers_flag.empty? || pipeline_workers.empty?
+      args << "#{pipeline_workers_flag} #{pipeline_workers}" unless pipeline_workers_flag.empty? || pipeline_workers <= 0
       args << custom_args unless custom_args.empty?
 
       args.join(' ')

--- a/libraries/logstash_service_systemd.rb
+++ b/libraries/logstash_service_systemd.rb
@@ -22,19 +22,19 @@ module SimpleLogstashCookbook
     property :systemd_unit_hash, [String, Hash], default: lazy {
       {
         'Unit' => {
-          'Description' => "Logstash #{new_resource.instance_name} service",
+          'Description' => "Logstash #{instance_name} service",
           'After' => 'network.target',
           'Documentation' => 'https://www.elastic.co/products/logstash'
         },
         'Service' => {
-          'User' => new_resource.user,
-          'Group' => new_resource.group,
-          'ExecStart' => new_resource.logstash_exec,
-          'EnvironmentFile' => env_file.path,
+          'User' => user,
+          'Group' => group,
+          'ExecStart' => logstash_exec,
+          'EnvironmentFile' => "/etc/default/#{instance_name}",
           'Restart' => 'always',
           'RestartSec' => '1 min',
           'LimitNICE' => 19,
-          'LimitNOFILE' => new_resource.max_open_files
+          'LimitNOFILE' => max_open_files
         },
         'Install' => {
           'WantedBy' => 'multi-user.target'
@@ -54,7 +54,7 @@ module SimpleLogstashCookbook
 
       def service_resource
         find_resource(:systemd_unit, "#{new_resource.instance_name}.service") do
-          content(new_resource.systemd_unit_hash)
+          content new_resource.systemd_unit_hash
 
           triggers_reload true
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Yauhen Artsiukhou'
 maintainer_email 'jsirex@gmail.com'
 license          'Apache-2.0'
 description      'Installs/Configures simple-logstash. No less. No more.'
-version          '1.0.1'
+version          '1.0.2'
 
 issues_url       'https://github.com/jsirex/simple-logstash-cookbook/issues'
 source_url       'https://github.com/jsirex/simple-logstash-cookbook'

--- a/test/fixtures/cookbooks/simple-logstash-spec/recipes/logstash_service.rb
+++ b/test/fixtures/cookbooks/simple-logstash-spec/recipes/logstash_service.rb
@@ -15,29 +15,3 @@ end
 logstash_service 'runit-provider' do
   provider :logstash_service_runit
 end
-
-content = {
-  'Unit' => {
-    'Description' => "Logstash service",
-    'After' => 'network.target',
-    'Documentation' => 'https://www.elastic.co/products/logstash'
-  },
-  'Service' => {
-    'User' => 'Logstash',
-    'Group' => 'Logstash',
-    'ExecStart' => '/opt/logstash/bin/logstash --path.config /etc/logstash/conf.d --path.data /var/lib/logstash/data --path.logs /var/log/logstash --pipeline.workers 1 --config.reload.automatic --log.level error',
-    'EnvironmentFile' => '/etc/default/logstash',
-    'Restart' => 'always',
-    'RestartSec' => '1 min',
-    'LimitNICE' => 19,
-    'LimitNOFILE' => '16384'
-  },
-  'Install' => {
-    'WantedBy' => 'multi-user.target'
-  },
-}
-
-logstash_service_systemd 'systemd-unit' do
-  provider :logstash_service_systemd
-  systemd_unit_hash content
-end

--- a/test/fixtures/cookbooks/simple-logstash-test/recipes/systemd-unit.rb
+++ b/test/fixtures/cookbooks/simple-logstash-test/recipes/systemd-unit.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+include_recipe 'java'
+include_recipe 'simple-logstash'
+
+# Setup directory with few samples
+remote_directory '/tmp/samples' do
+  source 'samples'
+  owner 'root'
+  group 'root'
+  mode '0777'
+  files_mode '0644'
+  files_owner 'root'
+  files_group 'root'
+end
+
+# Test one
+logstash_output 'test1'
+logstash_input 'test1'
+logstash_filter 'test1'
+
+content = {
+  'Unit' => {
+    'Description' => "Logstash service",
+    'After' => 'network.target',
+    'Documentation' => 'https://www.elastic.co/products/logstash'
+  },
+  'Service' => {
+    'User' => 'logstash',
+    'Group' => 'logstash',
+    'ExecStart' => '/opt/logstash/bin/logstash --path.config /etc/logstash/conf.d --path.data /var/lib/logstash/data --path.logs /var/log/logstash --pipeline.workers 1 --config.reload.automatic --log.level error',
+    'EnvironmentFile' => '/etc/default/logstash',
+    'Restart' => 'always',
+    'RestartSec' => '1 min',
+    'LimitNICE' => 19,
+    'LimitNOFILE' => '16384'
+  },
+  'Install' => {
+    'WantedBy' => 'multi-user.target'
+  },
+}
+
+logstash_service 'logstash' do
+  systemd_unit_hash content
+end

--- a/test/integration/systemd-unit/systemd-unit_spec.rb
+++ b/test/integration/systemd-unit/systemd-unit_spec.rb
@@ -1,0 +1,35 @@
+describe file('/etc/systemd/system/logstash.service') do
+  it { should exist }
+
+  systemd_config = [
+    '\[Unit\]',
+    'Description = Logstash service',
+    'After = network\.target',
+    'Documentation = https://www.elastic.co/products/logstash',
+    '',
+    '\[Service\]',
+    'User = logstash',
+    'Group = logstash',
+    'ExecStart = /opt/logstash/bin/logstash --path\.config /etc/logstash/conf\.d --path\.data /var/lib/logstash/data --path\.logs /var/log/logstash --pipeline\.workers 1 --config\.reload.automatic --log\.level error',
+    'EnvironmentFile = /etc/default/logstash',
+    'Restart = always',
+    'RestartSec = 1 min',
+    'LimitNICE = 19',
+    'LimitNOFILE = 16384',
+    '',
+    '\[Install\]',
+    'WantedBy = multi-user\.target',
+  ]
+  its('content') { should match(%r{^#{systemd_config.join('\n')}$})}
+end
+
+
+
+describe command('/opt/logstash/bin/logstash --config.test_and_exit -f /etc/logstash/conf.d') do
+  its(:exit_status) { should eq 0 }
+end
+
+describe service('logstash') do
+  it { should be_enabled }
+  it { should be_running }
+end


### PR DESCRIPTION
## What does this do?

1. Adds the `systemd_unit_hash` to the readme (seems it was lost in release)
1. Fixes the default `systemd_unit_hash` value that was inappropriately referencing `new_resource`
1. Adds an integration test for the `systemd_unit_hash` run `kitchen test systemd-unit` - Passes for all platforms in `kitchen.yml`
1. Fixes an `empty?` check on Integer `pipeline_workers` 